### PR TITLE
Allow running on read-only file system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk add --no-cache bash jq coreutils
 WORKDIR /opt/test-runner
 COPY . .
 
+ENV CRYSTAL_CACHE_DIR=/tmp/.cache/.crystal
+
 RUN ./bin/build.sh
 
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -35,8 +35,9 @@ docker build --rm -t exercism/test-runner .
 # Run the Docker image using the settings mimicking the production environment
 docker run \
     --rm \
+    --read-only \
     --network none \
     --mount type=bind,src="${input_dir}",dst=/solution \
     --mount type=bind,src="${output_dir}",dst=/output \
-    --mount type=tmpfs,dst=/tmp \
+    --mount type=volume,dst=/tmp \
     exercism/test-runner "${slug}" /solution /output

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -18,9 +18,10 @@ docker build --rm -t exercism/test-runner .
 # Run the Docker image using the settings mimicking the production environment
 docker run \
     --rm \
+    --read-only \
     --network none \
     --mount type=bind,src="${PWD}/tests",dst=/opt/test-runner/tests \
-    --mount type=tmpfs,dst=/tmp \
+    --mount type=volume,dst=/tmp \
     --workdir /opt/test-runner \
     --entrypoint /opt/test-runner/bin/run-tests.sh \
     exercism/test-runner


### PR DESCRIPTION
For some reason, some tools don't like writing to a `tmpfs` file system but do write to a `volume` bind.
